### PR TITLE
Hunt Scanner 2.3

### DIFF
--- a/Remix/BurpRemix/build.gradle
+++ b/Remix/BurpRemix/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-version = "2.2"
+version = "2.3"
 
 buildscript {
 

--- a/Remix/BurpRemix/src/main/kotlin/BurpExtender.kt
+++ b/Remix/BurpRemix/src/main/kotlin/BurpExtender.kt
@@ -1,5 +1,7 @@
 package burp
 
+import javax.swing.SwingUtilities
+
 class BurpExtender : IBurpExtender {
     override fun registerExtenderCallbacks(callbacks: IBurpExtenderCallbacks) {
         val tab = HuntTab(callbacks)
@@ -12,7 +14,13 @@ class BurpExtender : IBurpExtender {
                 write("\nRemixed by: Caleb (cak) Kinney (derail.io)".toByteArray())
             }
             setExtensionName("HUNT")
-            addSuiteTab(tab)
+        }
+
+        SwingUtilities.invokeLater {
+            callbacks.addSuiteTab(tab)
+            if ((callbacks.loadExtensionSetting(HuntOptions.IMPORT_PROXY_ON_START) ?: "false").toBoolean()) {
+                HuntUtils(callbacks, tab.huntPanel).importProxyHistory()
+            }
         }
     }
 }

--- a/Remix/BurpRemix/src/main/kotlin/BurpExtender.kt
+++ b/Remix/BurpRemix/src/main/kotlin/BurpExtender.kt
@@ -3,12 +3,16 @@ package burp
 class BurpExtender : IBurpExtender {
     override fun registerExtenderCallbacks(callbacks: IBurpExtenderCallbacks) {
         val tab = HuntTab(callbacks)
-        callbacks.registerHttpListener(HuntListener(callbacks, tab))
-        callbacks.stdout.write("HUNT - v2.2".toByteArray())
-        callbacks.stdout.write("\nOriginally by: JP Villanueva, Jason Haddix and team at Bugcrowd".toByteArray())
-        callbacks.stdout.write("\nRepo: https://github.com/bugcrowd/HUNT".toByteArray())
-        callbacks.stdout.write("\nRemixed by: Caleb Kinney (derail.io)".toByteArray())
-        callbacks.setExtensionName("HUNT")
-        callbacks.addSuiteTab(tab)
+        callbacks.apply {
+            registerHttpListener(HuntListener(callbacks, tab))
+            stdout.apply {
+                write("HUNT - v2.3".toByteArray())
+                write("\nOriginally by: JP Villanueva, Jason Haddix and team at Bugcrowd".toByteArray())
+                write("\nRepo: https://github.com/bugcrowd/HUNT".toByteArray())
+                write("\nRemixed by: Caleb (cak) Kinney (derail.io)".toByteArray())
+            }
+            setExtensionName("HUNT")
+            addSuiteTab(tab)
+        }
     }
 }

--- a/Remix/BurpRemix/src/main/kotlin/BurpExtender.kt
+++ b/Remix/BurpRemix/src/main/kotlin/BurpExtender.kt
@@ -18,7 +18,7 @@ class BurpExtender : IBurpExtender {
 
         SwingUtilities.invokeLater {
             callbacks.addSuiteTab(tab)
-            if ((callbacks.loadExtensionSetting(HuntOptions.IMPORT_PROXY_ON_START) ?: "false").toBoolean()) {
+            if ((callbacks.loadExtensionSetting(HuntOptions.IMPORT_PROXY_ON_START) ?: "true").toBoolean()) {
                 HuntUtils(callbacks, tab.huntPanel).importProxyHistory()
             }
         }

--- a/Remix/BurpRemix/src/main/kotlin/HuntData.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntData.kt
@@ -269,7 +269,7 @@ class HuntData {
     )
 
     private val issues =
-        mutableListOf(
+        listOf(
             insecureDirectObjectReference,
             osCommandInjection,
             fileInclusionPathTraversal,
@@ -291,9 +291,9 @@ data class HuntDetail(
     val name: String,
     val shortName: String?,
     val params: Set<String>,
+    val detail: String,
     val checkLocation: HuntLocation,
     var enabled: Boolean = true,
-    val detail: String,
     val level: String
 )
 

--- a/Remix/BurpRemix/src/main/kotlin/HuntFilters.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntFilters.kt
@@ -1,0 +1,115 @@
+package burp
+
+import java.awt.FlowLayout
+import javax.swing.*
+
+
+class HuntFilters(
+    private val huntPanel: HuntPanel,
+    private val callbacks: IBurpExtenderCallbacks
+) {
+    val panel = JSplitPane(JSplitPane.HORIZONTAL_SPLIT)
+    private val loadPanel = JPanel(FlowLayout(FlowLayout.RIGHT))
+    private val filterBar = JTextField("", 20)
+    private val filterPanel = JPanel(FlowLayout(FlowLayout.LEFT))
+    private val typeComboBox = JComboBox(arrayOf<String>())
+    val huntOptions = HuntOptions(callbacks)
+
+    init {
+        val clearButton = JButton("Clear Issues")
+        val filterLabel = JLabel("Filter HUNT Issues:")
+        val filterButton = JButton("Filter")
+        val resetButton = JButton("Reset")
+        val typeLabel = JLabel("Types:")
+        val optionsButton = JButton("Options")
+        typeComboBox.prototypeDisplayValue = "File Inclusion and Path Traversal  "
+        clearButton.addActionListener { clearHuntIssues() }
+        filterBar.addActionListener { filterHuntIssues() }
+        filterButton.addActionListener { filterHuntIssues() }
+        resetButton.addActionListener { resetFilter() }
+        optionsButton.addActionListener { huntOptions.optionFrame.isVisible = true }
+        filterPanel.add(filterLabel)
+        filterPanel.add(filterBar)
+        filterPanel.add(typeLabel)
+        filterPanel.add(typeComboBox)
+        filterPanel.add(filterButton)
+        filterPanel.add(resetButton)
+        loadPanel.add(clearButton)
+        loadPanel.add(optionsButton)
+        panel.leftComponent = filterPanel
+        panel.rightComponent = loadPanel
+        panel.dividerSize = 0
+    }
+
+    fun filtered(): Boolean {
+        return if (typeComboBox.selectedItem != "All" || filterBar.text.isNotEmpty()) {
+            filterHuntIssues()
+            true
+        } else {
+            false
+        }
+    }
+
+    private fun filterHuntIssues() {
+        val selectedType = typeComboBox.selectedItem ?: "All"
+        SwingUtilities.invokeLater {
+            val searchText = filterBar.text.toLowerCase()
+            var filteredHuntIssues = this.huntPanel.model.huntIssues
+            filteredHuntIssues = filterTypes(filteredHuntIssues)
+            if (searchText.isNotEmpty()) {
+                filteredHuntIssues = filteredHuntIssues
+                    .filter {
+                        it.comments.toLowerCase().contains(searchText) ||
+                                it.url.toString().toLowerCase().contains(searchText) ||
+                                callbacks.helpers.bytesToString(it.requestResponse.request).toLowerCase().contains(
+                                    searchText
+                                ) ||
+                                callbacks.helpers.bytesToString(
+                                    it.requestResponse.response ?: ByteArray(0)
+                                ).toLowerCase().contains(
+                                    searchText
+                                )
+                    }.toMutableList()
+            }
+            huntPanel.model.refreshHunt(filteredHuntIssues)
+            if (selectedType != "All") {
+                typeComboBox.selectedItem = selectedType
+            }
+        }
+    }
+
+    private fun filterTypes(huntIssues: MutableList<HuntIssue>): MutableList<HuntIssue> {
+        val selectedType = typeComboBox.selectedItem ?: "All"
+        return if (selectedType != "All") {
+            val type = typeComboBox.selectedItem
+            huntIssues
+                .filter {
+                    it.types.contains(HuntData().nameToShortName[type])
+                }.toMutableList()
+        } else {
+            huntIssues
+        }
+    }
+
+    private fun resetFilter() {
+        filterBar.text = ""
+        huntPanel.model.refreshHunt()
+        updateTypes()
+        huntPanel.requestViewer?.setMessage(ByteArray(0), true)
+        huntPanel.responseViewer?.setMessage(ByteArray(0), false)
+    }
+
+    private fun clearHuntIssues() {
+        huntPanel.model.clearHunt()
+        huntPanel.requestViewer?.setMessage(ByteArray(0), true)
+        huntPanel.responseViewer?.setMessage(ByteArray(0), false)
+    }
+
+    fun updateTypes() {
+        typeComboBox.removeAllItems()
+        typeComboBox.addItem("All")
+        for (type in huntPanel.model.types.sorted()) {
+            typeComboBox.addItem(type)
+        }
+    }
+}

--- a/Remix/BurpRemix/src/main/kotlin/HuntFilters.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntFilters.kt
@@ -22,12 +22,19 @@ class HuntFilters(
         val resetButton = JButton("Reset")
         val typeLabel = JLabel("Types:")
         val optionsButton = JButton("Options")
+        val importProxyHistory = JButton("Import Proxy History")
+
         typeComboBox.prototypeDisplayValue = "File Inclusion and Path Traversal  "
         clearButton.addActionListener { clearHuntIssues() }
         filterBar.addActionListener { filterHuntIssues() }
         filterButton.addActionListener { filterHuntIssues() }
         resetButton.addActionListener { resetFilter() }
         optionsButton.addActionListener { huntOptions.optionFrame.isVisible = true }
+        importProxyHistory.addActionListener {
+            SwingUtilities.invokeLater {
+                HuntUtils(callbacks, huntPanel).importProxyHistory()
+            }
+        }
         filterPanel.add(filterLabel)
         filterPanel.add(filterBar)
         filterPanel.add(typeLabel)
@@ -36,6 +43,7 @@ class HuntFilters(
         filterPanel.add(resetButton)
         loadPanel.add(clearButton)
         loadPanel.add(optionsButton)
+        loadPanel.add(importProxyHistory)
         panel.leftComponent = filterPanel
         panel.rightComponent = loadPanel
         panel.dividerSize = 0

--- a/Remix/BurpRemix/src/main/kotlin/HuntListener.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntListener.kt
@@ -1,105 +1,17 @@
 package burp
 
-import java.net.URL
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-
-
 class HuntListener(private val callbacks: IBurpExtenderCallbacks, private val huntTab: HuntTab) : IHttpListener {
     private val helpers: IExtensionHelpers = callbacks.helpers
 
     override fun processHttpMessage(toolFlag: Int, messageIsRequest: Boolean, messageInfo: IHttpRequestResponse?) {
-        messageInfo?.let {
+        messageInfo?.let { req ->
             val request = helpers.analyzeRequest(messageInfo) ?: return
             if (!messageIsRequest && callbacks.isInScope(request.url)
                 && (toolFlag == IBurpExtenderCallbacks.TOOL_PROXY || toolFlag == IBurpExtenderCallbacks.TOOL_SPIDER)
                 && (request.method != "OPTIONS" || request.method != "HEAD")
             ) {
-                val requestInfo = helpers.analyzeRequest(messageInfo) ?: return
-                val parameters = requestInfo.parameters
-                val huntIssues =
-                    parameters.asSequence().map { param -> checkParameterName(param.name.toLowerCase()) }
-                        .filterNotNull().filter { !it.second.isNullOrEmpty() }.map {
-                            makeHuntRequest(
-                                requestResponse = messageInfo,
-                                parameter = it.first,
-                                types = it.second
-                            )
-                        }.toList()
-
-                if (huntIssues.isNotEmpty()) {
-                    huntTab.huntTable.addHuntIssue(huntIssues)
-                    if (toolFlag == IBurpExtenderCallbacks.TOOL_PROXY) {
-                        messageInfo.highlight = "cyan"
-                        messageInfo.comment = "HUNT: ${huntIssues.map { it.types }.flatten().toSet().joinToString()}"
-                    }
-                }
+                HuntUtils(callbacks, toolFlag, huntTab).huntScan(req)
             }
         }
     }
-
-    private fun checkParameterName(param: String) =
-        Pair(param, HuntData().huntParams.asSequence().filter { it.params.contains(param) }.map { it.name }.toSet())
-
-    private fun makeHuntRequest(
-        requestResponse: IHttpRequestResponse,
-        parameter: String,
-        types: Set<String>
-    ): HuntIssue {
-        val now = LocalDateTime.now()
-        val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-        val dateTime = now.format(dateFormatter) ?: ""
-        val typeNames = types.map { HuntData().nameToShortName[it] ?: it }.toSet()
-        val requestInfo = callbacks.helpers.analyzeRequest(requestResponse)
-        val response = if (requestResponse.response != null) {
-            callbacks.helpers.analyzeResponse(requestResponse.response)
-        } else {
-            null
-        }
-
-
-        return HuntIssue(
-            requestResponse = callbacks.saveBuffersToTempFiles(requestResponse),
-            dateTime = dateTime,
-            host = requestInfo.url.host,
-            url = requestInfo.url,
-            types = typeNames,
-            parameter = parameter,
-            method = requestInfo?.method ?: "",
-            statusCode = response?.statusCode ?: 0,
-            title = getTitle(requestResponse.response),
-            length = requestResponse.response?.size ?: 0,
-            mimeType = response?.inferredMimeType ?: "",
-            protocol = requestInfo?.url?.protocol ?: "",
-            file = requestInfo?.url?.file ?: "",
-            comments = requestResponse.comment ?: ""
-        )
-    }
-
-    private fun getTitle(response: ByteArray?): String {
-        if (response == null) return ""
-        val html = callbacks.helpers.bytesToString(response)
-        val titleRegex = "<title>(.*?)</title>".toRegex()
-        val title = titleRegex.find(html)?.value ?: ""
-        return title.removePrefix("<title>").removeSuffix("</title>")
-    }
 }
-
-data class HuntIssue(
-    val requestResponse: IHttpRequestResponsePersisted,
-    val dateTime: String,
-    val host: String,
-    val url: URL,
-    val types: Set<String>,
-    val parameter: String,
-    val method: String,
-    val statusCode: Short,
-    val title: String,
-    val length: Int,
-    val mimeType: String,
-    val protocol: String,
-    val file: String,
-    var comments: String
-)
-
-

--- a/Remix/BurpRemix/src/main/kotlin/HuntListener.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntListener.kt
@@ -5,13 +5,7 @@ class HuntListener(private val callbacks: IBurpExtenderCallbacks, private val hu
 
     override fun processHttpMessage(toolFlag: Int, messageIsRequest: Boolean, messageInfo: IHttpRequestResponse?) {
         messageInfo?.let { req ->
-            val request = helpers.analyzeRequest(messageInfo) ?: return
-            if (!messageIsRequest && callbacks.isInScope(request.url)
-                && (toolFlag == IBurpExtenderCallbacks.TOOL_PROXY || toolFlag == IBurpExtenderCallbacks.TOOL_SPIDER)
-                && (request.method != "OPTIONS" || request.method != "HEAD")
-            ) {
-                HuntUtils(callbacks, toolFlag, huntTab).huntScan(req)
-            }
+            HuntUtils(callbacks, huntTab.huntPanel).huntScan(req, toolFlag = toolFlag)
         }
     }
 }

--- a/Remix/BurpRemix/src/main/kotlin/HuntListener.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntListener.kt
@@ -1,7 +1,6 @@
 package burp
 
 class HuntListener(private val callbacks: IBurpExtenderCallbacks, private val huntTab: HuntTab) : IHttpListener {
-    private val helpers: IExtensionHelpers = callbacks.helpers
 
     override fun processHttpMessage(toolFlag: Int, messageIsRequest: Boolean, messageInfo: IHttpRequestResponse?) {
         messageInfo?.let { req ->

--- a/Remix/BurpRemix/src/main/kotlin/HuntListener.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntListener.kt
@@ -4,7 +4,9 @@ class HuntListener(private val callbacks: IBurpExtenderCallbacks, private val hu
 
     override fun processHttpMessage(toolFlag: Int, messageIsRequest: Boolean, messageInfo: IHttpRequestResponse?) {
         messageInfo?.let { req ->
-            HuntUtils(callbacks, huntTab.huntPanel).huntScan(req, toolFlag = toolFlag)
+            if (!messageIsRequest) {
+                HuntUtils(callbacks, huntTab.huntPanel).huntScan(req, toolFlag = toolFlag)
+            }
         }
     }
 }

--- a/Remix/BurpRemix/src/main/kotlin/HuntOptions.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntOptions.kt
@@ -9,7 +9,7 @@ import javax.swing.JPanel
 class HuntOptions(callbacks: IBurpExtenderCallbacks) {
     val optionFrame = JFrame("HUNT Options")
     private val fetchHistoryOnStart = JCheckBox("Fetch proxy history on start")
-    val noDuplicateIssues = JCheckBox("Do not add duplicate issues")
+    val noDuplicateIssues = JCheckBox("Ignore duplicate issues")
     val ignoreHostDuplicates = JCheckBox("Ignore host when considering duplicate issues")
     val highlightProxyHistory = JCheckBox("Highlight proxy history")
 

--- a/Remix/BurpRemix/src/main/kotlin/HuntOptions.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntOptions.kt
@@ -1,111 +1,43 @@
 package burp
 
-import java.awt.FlowLayout
-import javax.swing.*
+import java.awt.BorderLayout
+import javax.swing.BoxLayout
+import javax.swing.JCheckBox
+import javax.swing.JFrame
+import javax.swing.JPanel
 
-
-class HuntOptions(
-        private val huntPanel: HuntPanel,
-        private val callbacks: IBurpExtenderCallbacks
-) {
-    val panel = JSplitPane(JSplitPane.HORIZONTAL_SPLIT)
-    private val loadPanel = JPanel(FlowLayout(FlowLayout.RIGHT))
-    private val filterBar = JTextField("", 20)
-    private val filterPanel = JPanel(FlowLayout(FlowLayout.LEFT))
-    private val typeComboBox = JComboBox(arrayOf<String>())
+class HuntOptions(callbacks: IBurpExtenderCallbacks) {
+    val optionFrame = JFrame("HUNT Options")
+    val fetchHistoryOnStart = JCheckBox("Fetch proxy history on start")
+    val noDuplicateIssues = JCheckBox("Do not add duplicate issues")
 
     init {
-        val clearButton = JButton("Clear Issues")
-        val filterLabel = JLabel("Filter HUNT Issues:")
-        val filterButton = JButton("Filter")
-        val resetButton = JButton("Reset")
-        val typeLabel = JLabel("Types:")
-        typeComboBox.prototypeDisplayValue = "File Inclusion and Path Traversal  "
-        clearButton.addActionListener { clearHuntIssues() }
-        filterBar.addActionListener { filterHuntIssues() }
-        filterButton.addActionListener { filterHuntIssues() }
-        resetButton.addActionListener { resetFilter() }
-        filterPanel.add(filterLabel)
-        filterPanel.add(filterBar)
-        filterPanel.add(typeLabel)
-        filterPanel.add(typeComboBox)
-        filterPanel.add(filterButton)
-        filterPanel.add(resetButton)
-        loadPanel.add(clearButton)
-        panel.leftComponent = filterPanel
-        panel.rightComponent = loadPanel
-        panel.dividerSize = 0
-    }
-
-    fun filtered(): Boolean {
-        return if (typeComboBox.selectedItem != "All" || filterBar.text.isNotEmpty()) {
-            filterHuntIssues()
-            true
-        } else {
-            false
+        val optionsPanel = JPanel()
+        fetchHistoryOnStart.isSelected = (callbacks.loadExtensionSetting(IMPORT_PROXY_ON_START) ?: "false").toBoolean()
+        noDuplicateIssues.isSelected = (callbacks.loadExtensionSetting(NO_DUP_ISSUES) ?: "true").toBoolean()
+        fetchHistoryOnStart.addActionListener {
+            callbacks.saveExtensionSetting(
+                IMPORT_PROXY_ON_START,
+                fetchHistoryOnStart.isSelected.toString()
+            )
         }
-    }
-
-    private fun filterHuntIssues() {
-        val selectedType = typeComboBox.selectedItem ?: "All"
-        SwingUtilities.invokeLater {
-            val searchText = filterBar.text.toLowerCase()
-            var filteredHuntIssues = this.huntPanel.model.huntIssues
-            filteredHuntIssues = filterTypes(filteredHuntIssues)
-            if (searchText.isNotEmpty()) {
-                filteredHuntIssues = filteredHuntIssues
-                        .filter {
-                            it.comments.toLowerCase().contains(searchText) ||
-                                    it.url.toString().toLowerCase().contains(searchText) ||
-                                    callbacks.helpers.bytesToString(it.requestResponse.request).toLowerCase().contains(
-                                            searchText
-                                    ) ||
-                                    callbacks.helpers.bytesToString(
-                                            it.requestResponse.response ?: ByteArray(0)
-                                    ).toLowerCase().contains(
-                                            searchText
-                                    )
-                        }.toMutableList()
-            }
-            huntPanel.model.refreshHunt(filteredHuntIssues)
-            if (selectedType != "All") {
-                typeComboBox.selectedItem = selectedType
-            }
+        noDuplicateIssues.addActionListener {
+            callbacks.saveExtensionSetting(
+                NO_DUP_ISSUES,
+                noDuplicateIssues.isSelected.toString()
+            )
         }
+        optionsPanel.layout = BoxLayout(optionsPanel, BoxLayout.Y_AXIS)
+        optionsPanel.add(fetchHistoryOnStart)
+        optionsPanel.add(noDuplicateIssues)
+        optionFrame.defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+        optionFrame.contentPane.add(optionsPanel, BorderLayout.CENTER)
+        optionFrame.setLocationRelativeTo(null)
+        optionFrame.pack()
     }
 
-    private fun filterTypes(huntIssues: MutableList<HuntIssue>): MutableList<HuntIssue> {
-        val selectedType = typeComboBox.selectedItem ?: "All"
-        return if (selectedType != "All") {
-            val type = typeComboBox.selectedItem
-            huntIssues
-                    .filter {
-                        it.types.contains(HuntData().nameToShortName[type])
-                    }.toMutableList()
-        } else {
-            huntIssues
-        }
-    }
-
-    private fun resetFilter() {
-        filterBar.text = ""
-        huntPanel.model.refreshHunt()
-        updateTypes()
-        huntPanel.requestViewer?.setMessage(ByteArray(0), true)
-        huntPanel.responseViewer?.setMessage(ByteArray(0), false)
-    }
-
-    private fun clearHuntIssues() {
-        huntPanel.model.clearHunt()
-        huntPanel.requestViewer?.setMessage(ByteArray(0), true)
-        huntPanel.responseViewer?.setMessage(ByteArray(0), false)
-    }
-
-    fun updateTypes() {
-        typeComboBox.removeAllItems()
-        typeComboBox.addItem("All")
-        for (type in huntPanel.model.types.sorted()) {
-            typeComboBox.addItem(type)
-        }
+    companion object {
+        const val IMPORT_PROXY_ON_START = "import proxy on start"
+        const val NO_DUP_ISSUES = "no dup issues"
     }
 }

--- a/Remix/BurpRemix/src/main/kotlin/HuntOptions.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntOptions.kt
@@ -10,11 +10,16 @@ class HuntOptions(callbacks: IBurpExtenderCallbacks) {
     val optionFrame = JFrame("HUNT Options")
     val fetchHistoryOnStart = JCheckBox("Fetch proxy history on start")
     val noDuplicateIssues = JCheckBox("Do not add duplicate issues")
+    val highlightProxyHistory = JCheckBox("Highlight proxy history")
+
 
     init {
         val optionsPanel = JPanel()
         fetchHistoryOnStart.isSelected = (callbacks.loadExtensionSetting(IMPORT_PROXY_ON_START) ?: "false").toBoolean()
         noDuplicateIssues.isSelected = (callbacks.loadExtensionSetting(NO_DUP_ISSUES) ?: "true").toBoolean()
+        highlightProxyHistory.isSelected =
+            (callbacks.loadExtensionSetting(HIGHLIGHT_PROXY_HISTORY) ?: "false").toBoolean()
+
         fetchHistoryOnStart.addActionListener {
             callbacks.saveExtensionSetting(
                 IMPORT_PROXY_ON_START,
@@ -27,9 +32,17 @@ class HuntOptions(callbacks: IBurpExtenderCallbacks) {
                 noDuplicateIssues.isSelected.toString()
             )
         }
+
+        highlightProxyHistory.addActionListener {
+            callbacks.saveExtensionSetting(
+                HIGHLIGHT_PROXY_HISTORY,
+                highlightProxyHistory.isSelected.toString()
+            )
+        }
         optionsPanel.layout = BoxLayout(optionsPanel, BoxLayout.Y_AXIS)
         optionsPanel.add(fetchHistoryOnStart)
         optionsPanel.add(noDuplicateIssues)
+        optionsPanel.add(highlightProxyHistory)
         optionFrame.defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
         optionFrame.contentPane.add(optionsPanel, BorderLayout.CENTER)
         optionFrame.setLocationRelativeTo(null)
@@ -39,5 +52,6 @@ class HuntOptions(callbacks: IBurpExtenderCallbacks) {
     companion object {
         const val IMPORT_PROXY_ON_START = "import proxy on start"
         const val NO_DUP_ISSUES = "no dup issues"
+        const val HIGHLIGHT_PROXY_HISTORY = "highlight proxy history"
     }
 }

--- a/Remix/BurpRemix/src/main/kotlin/HuntOptions.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntOptions.kt
@@ -8,40 +8,49 @@ import javax.swing.JPanel
 
 class HuntOptions(callbacks: IBurpExtenderCallbacks) {
     val optionFrame = JFrame("HUNT Options")
-    val fetchHistoryOnStart = JCheckBox("Fetch proxy history on start")
+    private val fetchHistoryOnStart = JCheckBox("Fetch proxy history on start")
     val noDuplicateIssues = JCheckBox("Do not add duplicate issues")
+    val ignoreHostDuplicates = JCheckBox("Ignore host when considering duplicate issues")
     val highlightProxyHistory = JCheckBox("Highlight proxy history")
 
 
     init {
         val optionsPanel = JPanel()
-        fetchHistoryOnStart.isSelected = (callbacks.loadExtensionSetting(IMPORT_PROXY_ON_START) ?: "false").toBoolean()
+        fetchHistoryOnStart.isSelected = (callbacks.loadExtensionSetting(IMPORT_PROXY_ON_START) ?: "true").toBoolean()
         noDuplicateIssues.isSelected = (callbacks.loadExtensionSetting(NO_DUP_ISSUES) ?: "true").toBoolean()
+        ignoreHostDuplicates.isSelected = (callbacks.loadExtensionSetting(IGNORE_HOST_DUPLICATES)
+                ?: "false").toBoolean()
         highlightProxyHistory.isSelected =
-            (callbacks.loadExtensionSetting(HIGHLIGHT_PROXY_HISTORY) ?: "false").toBoolean()
+                (callbacks.loadExtensionSetting(HIGHLIGHT_PROXY_HISTORY) ?: "false").toBoolean()
 
         fetchHistoryOnStart.addActionListener {
             callbacks.saveExtensionSetting(
-                IMPORT_PROXY_ON_START,
-                fetchHistoryOnStart.isSelected.toString()
+                    IMPORT_PROXY_ON_START,
+                    fetchHistoryOnStart.isSelected.toString()
             )
         }
         noDuplicateIssues.addActionListener {
             callbacks.saveExtensionSetting(
-                NO_DUP_ISSUES,
-                noDuplicateIssues.isSelected.toString()
+                    NO_DUP_ISSUES,
+                    noDuplicateIssues.isSelected.toString()
             )
         }
-
+        ignoreHostDuplicates.addActionListener {
+            callbacks.saveExtensionSetting(
+                    IGNORE_HOST_DUPLICATES,
+                    ignoreHostDuplicates.isSelected.toString()
+            )
+        }
         highlightProxyHistory.addActionListener {
             callbacks.saveExtensionSetting(
-                HIGHLIGHT_PROXY_HISTORY,
-                highlightProxyHistory.isSelected.toString()
+                    HIGHLIGHT_PROXY_HISTORY,
+                    highlightProxyHistory.isSelected.toString()
             )
         }
         optionsPanel.layout = BoxLayout(optionsPanel, BoxLayout.Y_AXIS)
         optionsPanel.add(fetchHistoryOnStart)
         optionsPanel.add(noDuplicateIssues)
+        optionsPanel.add(ignoreHostDuplicates)
         optionsPanel.add(highlightProxyHistory)
         optionFrame.defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
         optionFrame.contentPane.add(optionsPanel, BorderLayout.CENTER)
@@ -53,5 +62,6 @@ class HuntOptions(callbacks: IBurpExtenderCallbacks) {
         const val IMPORT_PROXY_ON_START = "import proxy on start"
         const val NO_DUP_ISSUES = "no dup issues"
         const val HIGHLIGHT_PROXY_HISTORY = "highlight proxy history"
+        const val IGNORE_HOST_DUPLICATES = "ignore host on duplicates"
     }
 }

--- a/Remix/BurpRemix/src/main/kotlin/HuntTab.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntTab.kt
@@ -20,9 +20,10 @@ class HuntTab(callbacks: IBurpExtenderCallbacks) : ITab {
 }
 
 class HuntPanel(private val callbacks: IBurpExtenderCallbacks) {
-    private val huntOptions = HuntOptions(this, callbacks)
-    val model = HuntModel(huntOptions)
+    val huntFilters = HuntFilters(this, callbacks)
+    val model = HuntModel(huntFilters)
     val table = JTable(model)
+    val huntIssues = model.huntIssues
 
     private val messageEditor = MessageEditor(callbacks)
     val requestViewer: IMessageEditor? = messageEditor.requestViewer
@@ -78,7 +79,7 @@ class HuntPanel(private val callbacks: IBurpExtenderCallbacks) {
             JSplitPane(JSplitPane.VERTICAL_SPLIT, repeatPanel, reqResSplit)
 
         val huntOptSplit =
-            JSplitPane(JSplitPane.VERTICAL_SPLIT, huntOptions.panel, huntTable)
+            JSplitPane(JSplitPane.VERTICAL_SPLIT, huntFilters.panel, huntTable)
 
         panel.topComponent = huntOptSplit
         panel.bottomComponent = repeatReqSplit
@@ -125,7 +126,7 @@ class MessageEditor(callbacks: IBurpExtenderCallbacks) : IMessageEditorControlle
     override fun getHttpService(): IHttpService? = requestResponse?.httpService
 }
 
-class HuntModel(private val huntOptions: HuntOptions) : AbstractTableModel() {
+class HuntModel(private val huntFilters: HuntFilters) : AbstractTableModel() {
     private val columns =
         listOf(
             "ID",
@@ -214,7 +215,7 @@ class HuntModel(private val huntOptions: HuntOptions) : AbstractTableModel() {
     }
 
     fun filterOrRefresh() {
-        if (!huntOptions.filtered()) {
+        if (!huntFilters.filtered()) {
             refreshHunt()
         }
     }
@@ -229,7 +230,7 @@ class HuntModel(private val huntOptions: HuntOptions) : AbstractTableModel() {
         val shortToName = HuntData().shortToName
         val newTypes = displayedHuntIssues.flatMap { it.types }.mapNotNull { shortToName[it] }.toSet().toList()
         types = newTypes
-        huntOptions.updateTypes()
+        huntFilters.updateTypes()
     }
 }
 

--- a/Remix/BurpRemix/src/main/kotlin/HuntTab.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntTab.kt
@@ -147,6 +147,10 @@ class HuntModel(private val huntOptions: HuntOptions) : AbstractTableModel() {
     var displayedHuntIssues: MutableList<HuntIssue> = ArrayList()
         private set
 
+    companion object {
+        private const val COMMENTS = 12
+    }
+
     override fun getRowCount(): Int = displayedHuntIssues.size
 
     override fun getColumnCount(): Int = columns.size
@@ -158,19 +162,11 @@ class HuntModel(private val huntOptions: HuntOptions) : AbstractTableModel() {
     override fun getColumnClass(columnIndex: Int): Class<*> {
         return when (columnIndex) {
             0 -> java.lang.Integer::class.java
-            1 -> String::class.java
-            2 -> String::class.java
-            3 -> String::class.java
-            4 -> String::class.java
-            5 -> String::class.java
-            6 -> String::class.java
-            7 -> String::class.java
+            in 1..7 -> String::class.java
             8 -> Short::class.java
             9 -> Integer::class.java
-            10 -> String::class.java
-            11 -> String::class.java
-            12 -> String::class.java
-            else -> throw RuntimeException()
+            in 10..12 -> String::class.java
+            else -> throw IndexOutOfBoundsException("$columnIndex is out of bounds.")
         }
     }
 
@@ -196,13 +192,7 @@ class HuntModel(private val huntOptions: HuntOptions) : AbstractTableModel() {
         }
     }
 
-
-    override fun isCellEditable(rowIndex: Int, columnIndex: Int): Boolean {
-        return when (columnIndex) {
-            12 -> true
-            else -> false
-        }
-    }
+    override fun isCellEditable(rowIndex: Int, columnIndex: Int) = columnIndex == COMMENTS
 
     override fun setValueAt(value: Any?, rowIndex: Int, colIndex: Int) {
         val huntIssue: HuntIssue = huntIssues[rowIndex]
@@ -250,13 +240,13 @@ class RequestResponse(private var req: ByteArray?, private var res: ByteArray?, 
 
     override fun setComment(comment: String?) {}
 
-    override fun getRequest(): ByteArray? = req
+    override fun getRequest() = req
 
     override fun getHighlight(): String? = null
 
     override fun getHttpService(): IHttpService? = service
 
-    override fun getResponse(): ByteArray? = res
+    override fun getResponse() = res
 
     override fun setResponse(message: ByteArray?) {
         res = message

--- a/Remix/BurpRemix/src/main/kotlin/HuntTab.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntTab.kt
@@ -12,11 +12,11 @@ import javax.swing.table.TableRowSorter
 
 
 class HuntTab(callbacks: IBurpExtenderCallbacks) : ITab {
-    val huntTable = HuntPanel(callbacks)
+    val huntPanel = HuntPanel(callbacks)
 
     override fun getTabCaption() = "HUNT"
 
-    override fun getUiComponent() = huntTable.panel
+    override fun getUiComponent() = huntPanel.panel
 }
 
 class HuntPanel(private val callbacks: IBurpExtenderCallbacks) {

--- a/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
@@ -93,7 +93,13 @@ class HuntUtils(
     }
 
     private fun checkIfDuplicate(huntIssue: HuntIssue): Boolean {
-        return huntTab.huntTable.huntIssues.any { it.url.host == huntIssue.url.host && it.url.path == huntIssue.url.path && it.parameter == huntIssue.parameter }
+        return huntPanel.huntIssues.any { it.url.host == huntIssue.url.host && it.url.path == huntIssue.url.path && it.parameter == huntIssue.parameter }
+    }
+
+    fun importProxyHistory() {
+        callbacks.proxyHistory.forEach {
+            huntScan(it, duplicates = false)
+        }
     }
 }
 

--- a/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
@@ -1,0 +1,116 @@
+package burp
+
+import java.net.URL
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+class HuntUtils(
+    private val callbacks: IBurpExtenderCallbacks,
+    private val toolFlag: Int,
+    private val huntTab: HuntTab
+) {
+    private val helpers: IExtensionHelpers = callbacks.helpers
+
+    fun huntScan(messageInfo: IHttpRequestResponse) {
+
+        val noDuplicates = huntTab.huntTable.huntFilters.huntOptions.noDuplicateIssues.isSelected
+
+        val huntIssues = huntScannerIssues(messageInfo)?.filterNot {
+            noDuplicates && checkIfDuplicate(it)
+        } ?: return
+
+        if (huntIssues.isNotEmpty()) {
+            huntTab.huntTable.addHuntIssue(huntIssues)
+            if (toolFlag == IBurpExtenderCallbacks.TOOL_PROXY) {
+                messageInfo.highlight = "cyan"
+                messageInfo.comment =
+                    "HUNT: ${huntIssues.map { issue -> issue.types }.flatten().toSet().joinToString()}"
+            }
+        }
+    }
+
+    private fun huntScannerIssues(messageInfo: IHttpRequestResponse): List<HuntIssue>? {
+        val requestInfo = helpers.analyzeRequest(messageInfo) ?: return null
+        val parameters = requestInfo.parameters.map { it.name.toLowerCase() }.sorted()
+
+        return parameters.asSequence().map { param -> checkParameterName(param) }
+            .filterNotNull().filter { !it.second.isNullOrEmpty() }.map {
+                makeHuntRequest(
+                    requestResponse = messageInfo,
+                    parameter = it.first,
+                    types = it.second,
+                    allParameters = parameters
+                )
+            }.toList()
+    }
+
+    private fun checkParameterName(param: String) =
+        Pair(param, HuntData().huntParams.asSequence().filter { it.params.contains(param) }.map { it.name }.toSet())
+
+    private fun makeHuntRequest(
+        requestResponse: IHttpRequestResponse,
+        parameter: String,
+        types: Set<String>,
+        allParameters: List<String>
+    ): HuntIssue {
+        val now = LocalDateTime.now()
+        val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        val dateTime = now.format(dateFormatter) ?: ""
+        val typeNames = types.map { HuntData().nameToShortName[it] ?: it }.toSet()
+        val requestInfo = callbacks.helpers.analyzeRequest(requestResponse)
+        val response = if (requestResponse.response != null) {
+            callbacks.helpers.analyzeResponse(requestResponse.response)
+        } else {
+            null
+        }
+
+
+        return HuntIssue(
+            requestResponse = callbacks.saveBuffersToTempFiles(requestResponse),
+            dateTime = dateTime,
+            host = requestInfo.url.host,
+            url = requestInfo.url,
+            types = typeNames,
+            parameter = parameter,
+            method = requestInfo?.method ?: "",
+            statusCode = response?.statusCode ?: 0,
+            title = getTitle(requestResponse.response),
+            length = requestResponse.response?.size ?: 0,
+            mimeType = response?.inferredMimeType ?: "",
+            protocol = requestInfo?.url?.protocol ?: "",
+            file = requestInfo?.url?.file ?: "",
+            comments = requestResponse.comment ?: "",
+            allParameters = allParameters
+        )
+    }
+
+    private fun getTitle(response: ByteArray?): String {
+        if (response == null) return ""
+        val html = callbacks.helpers.bytesToString(response)
+        val titleRegex = "<title>(.*?)</title>".toRegex()
+        val title = titleRegex.find(html)?.value ?: ""
+        return title.removePrefix("<title>").removeSuffix("</title>")
+    }
+
+    private fun checkIfDuplicate(huntIssue: HuntIssue): Boolean {
+        return huntTab.huntTable.huntIssues.any { it.url.host == huntIssue.url.host && it.url.path == huntIssue.url.path && it.parameter == huntIssue.parameter }
+    }
+}
+
+data class HuntIssue(
+    val requestResponse: IHttpRequestResponsePersisted,
+    val dateTime: String,
+    val host: String,
+    val url: URL,
+    val types: Set<String>,
+    val parameter: String,
+    val method: String,
+    val statusCode: Short,
+    val title: String,
+    val length: Int,
+    val mimeType: String,
+    val protocol: String,
+    val file: String,
+    var comments: String,
+    val allParameters: List<String>
+)

--- a/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
@@ -40,8 +40,7 @@ class HuntUtils(
         }
     }
 
-    private fun huntScannerIssues(messageInfo: IHttpRequestResponse): List<HuntIssue>? {
-        val requestInfo = helpers.analyzeRequest(messageInfo) ?: return null
+    private fun huntScannerIssues(requestInfo: IRequestInfo, messageInfo: IHttpRequestResponse): List<HuntIssue>? {
         val parameters = requestInfo.parameters.map { it.name.toLowerCase() }.sorted()
 
         return parameters.asSequence().map { param -> checkParameterName(param) }

--- a/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
@@ -104,7 +104,11 @@ class HuntUtils(
     }
 
     private fun checkIfDuplicate(huntIssue: HuntIssue): Boolean {
-        return huntPanel.huntIssues.any { it.url.host == huntIssue.url.host && it.url.path == huntIssue.url.path && it.parameter == huntIssue.parameter }
+        return if (huntPanel.huntFilters.huntOptions.ignoreHostDuplicates.isSelected) {
+            huntPanel.huntIssues.any { it.url.path == huntIssue.url.path && it.parameter == huntIssue.parameter }
+        } else {
+            huntPanel.huntIssues.any { it.url.host == huntIssue.url.host && it.url.path == huntIssue.url.path && it.parameter == huntIssue.parameter }
+        }
     }
 
     fun importProxyHistory() {

--- a/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
@@ -12,8 +12,7 @@ class HuntUtils(
 
     fun huntScan(
             messageInfo: IHttpRequestResponse,
-            toolFlag: Int = IBurpExtenderCallbacks.TOOL_PROXY,
-            duplicates: Boolean = true
+            toolFlag: Int = IBurpExtenderCallbacks.TOOL_PROXY
     ) {
         val request = helpers.analyzeRequest(messageInfo) ?: return
 
@@ -22,7 +21,7 @@ class HuntUtils(
                 && (request.method != "OPTIONS" || request.method != "HEAD")
         ) {
 
-            val noDuplicates = !duplicates || huntPanel.huntFilters.huntOptions.noDuplicateIssues.isSelected
+            val noDuplicates = huntPanel.huntFilters.huntOptions.noDuplicateIssues.isSelected
             val highlightProxyHistory = huntPanel.huntFilters.huntOptions.highlightProxyHistory.isSelected
 
             val huntIssues = huntScannerIssues(messageInfo)?.filterNot {
@@ -112,8 +111,9 @@ class HuntUtils(
     }
 
     fun importProxyHistory() {
+        val duplicates = huntPanel.huntFilters.huntOptions.noDuplicateIssues.isSelected
         callbacks.proxyHistory.forEach {
-            huntScan(it, duplicates = false)
+            huntScan(it)
         }
     }
 }

--- a/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
@@ -112,7 +112,6 @@ class HuntUtils(
     }
 
     fun importProxyHistory() {
-        val duplicates = huntPanel.huntFilters.huntOptions.noDuplicateIssues.isSelected
         callbacks.proxyHistory.forEach {
             huntScan(it)
         }

--- a/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
@@ -9,6 +9,7 @@ class HuntUtils(
         private val huntPanel: HuntPanel
 ) {
     private val helpers: IExtensionHelpers = callbacks.helpers
+    private val huntOptions = huntPanel.huntFilters.huntOptions
 
     fun huntScan(
             messageInfo: IHttpRequestResponse,
@@ -21,10 +22,10 @@ class HuntUtils(
                 && (request.method != "OPTIONS" || request.method != "HEAD")
         ) {
 
-            val noDuplicates = huntPanel.huntFilters.huntOptions.noDuplicateIssues.isSelected
-            val highlightProxyHistory = huntPanel.huntFilters.huntOptions.highlightProxyHistory.isSelected
+            val noDuplicates = huntOptions.noDuplicateIssues.isSelected
+            val highlightProxyHistory = huntOptions.highlightProxyHistory.isSelected
 
-            val huntIssues = huntScannerIssues(messageInfo)?.filterNot {
+            val huntIssues = huntScannerIssues(request, messageInfo)?.filterNot {
                 noDuplicates && checkIfDuplicate(it)
             } ?: return
 
@@ -103,7 +104,7 @@ class HuntUtils(
     }
 
     private fun checkIfDuplicate(huntIssue: HuntIssue): Boolean {
-        return if (huntPanel.huntFilters.huntOptions.ignoreHostDuplicates.isSelected) {
+        return if (huntOptions.ignoreHostDuplicates.isSelected) {
             huntPanel.huntIssues.any { it.url.path == huntIssue.url.path && it.parameter == huntIssue.parameter }
         } else {
             huntPanel.huntIssues.any { it.url.host == huntIssue.url.host && it.url.path == huntIssue.url.path && it.parameter == huntIssue.parameter }

--- a/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
+++ b/Remix/BurpRemix/src/main/kotlin/HuntUtils.kt
@@ -5,21 +5,21 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 class HuntUtils(
-    private val callbacks: IBurpExtenderCallbacks,
-    private val huntPanel: HuntPanel
+        private val callbacks: IBurpExtenderCallbacks,
+        private val huntPanel: HuntPanel
 ) {
     private val helpers: IExtensionHelpers = callbacks.helpers
 
     fun huntScan(
-        messageInfo: IHttpRequestResponse,
-        toolFlag: Int = IBurpExtenderCallbacks.TOOL_PROXY,
-        duplicates: Boolean = true
+            messageInfo: IHttpRequestResponse,
+            toolFlag: Int = IBurpExtenderCallbacks.TOOL_PROXY,
+            duplicates: Boolean = true
     ) {
         val request = helpers.analyzeRequest(messageInfo) ?: return
 
         if (callbacks.isInScope(request.url)
-            && (toolFlag == IBurpExtenderCallbacks.TOOL_PROXY || toolFlag == IBurpExtenderCallbacks.TOOL_SPIDER)
-            && (request.method != "OPTIONS" || request.method != "HEAD")
+                && (toolFlag == IBurpExtenderCallbacks.TOOL_PROXY || toolFlag == IBurpExtenderCallbacks.TOOL_SPIDER)
+                && (request.method != "OPTIONS" || request.method != "HEAD")
         ) {
 
             val noDuplicates = !duplicates || huntPanel.huntFilters.huntOptions.noDuplicateIssues.isSelected
@@ -34,7 +34,7 @@ class HuntUtils(
                 if (toolFlag == IBurpExtenderCallbacks.TOOL_PROXY && highlightProxyHistory) {
                     messageInfo.highlight = "cyan"
                     messageInfo.comment =
-                        "HUNT: ${huntIssues.map { issue -> issue.types }.flatten().toSet().joinToString()}"
+                            "HUNT: ${huntIssues.map { issue -> issue.types }.flatten().toSet().joinToString()}"
                 }
             }
         }
@@ -45,24 +45,24 @@ class HuntUtils(
         val parameters = requestInfo.parameters.map { it.name.toLowerCase() }.sorted()
 
         return parameters.asSequence().map { param -> checkParameterName(param) }
-            .filterNotNull().filter { !it.second.isNullOrEmpty() }.map {
-                makeHuntRequest(
-                    requestResponse = messageInfo,
-                    parameter = it.first,
-                    types = it.second,
-                    allParameters = parameters
-                )
-            }.toList()
+                .filterNotNull().filter { !it.second.isNullOrEmpty() }.map {
+                    makeHuntRequest(
+                            requestResponse = messageInfo,
+                            parameter = it.first,
+                            types = it.second,
+                            allParameters = parameters
+                    )
+                }.toList()
     }
 
     private fun checkParameterName(param: String) =
-        Pair(param, HuntData().huntParams.asSequence().filter { it.params.contains(param) }.map { it.name }.toSet())
+            Pair(param, HuntData().huntParams.asSequence().filter { it.params.contains(param) }.map { it.name }.toSet())
 
     private fun makeHuntRequest(
-        requestResponse: IHttpRequestResponse,
-        parameter: String,
-        types: Set<String>,
-        allParameters: List<String>
+            requestResponse: IHttpRequestResponse,
+            parameter: String,
+            types: Set<String>,
+            allParameters: List<String>
     ): HuntIssue {
         val now = LocalDateTime.now()
         val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
@@ -77,21 +77,21 @@ class HuntUtils(
 
 
         return HuntIssue(
-            requestResponse = callbacks.saveBuffersToTempFiles(requestResponse),
-            dateTime = dateTime,
-            host = requestInfo.url.host,
-            url = requestInfo.url,
-            types = typeNames,
-            parameter = parameter,
-            method = requestInfo?.method ?: "",
-            statusCode = response?.statusCode ?: 0,
-            title = getTitle(requestResponse.response),
-            length = requestResponse.response?.size ?: 0,
-            mimeType = response?.inferredMimeType ?: "",
-            protocol = requestInfo?.url?.protocol ?: "",
-            file = requestInfo?.url?.file ?: "",
-            comments = requestResponse.comment ?: "",
-            allParameters = allParameters
+                requestResponse = callbacks.saveBuffersToTempFiles(requestResponse),
+                dateTime = dateTime,
+                host = requestInfo.url.host,
+                url = requestInfo.url,
+                types = typeNames,
+                parameter = parameter,
+                method = requestInfo?.method ?: "",
+                statusCode = response?.statusCode ?: 0,
+                title = getTitle(requestResponse.response),
+                length = requestResponse.response?.size ?: 0,
+                mimeType = response?.inferredMimeType ?: "",
+                protocol = requestInfo?.url?.protocol ?: "",
+                file = requestInfo?.url?.file ?: "",
+                comments = requestResponse.comment ?: "",
+                allParameters = allParameters
         )
     }
 
@@ -119,19 +119,19 @@ class HuntUtils(
 }
 
 data class HuntIssue(
-    val requestResponse: IHttpRequestResponsePersisted,
-    val dateTime: String,
-    val host: String,
-    val url: URL,
-    val types: Set<String>,
-    val parameter: String,
-    val method: String,
-    val statusCode: Short,
-    val title: String,
-    val length: Int,
-    val mimeType: String,
-    val protocol: String,
-    val file: String,
-    var comments: String,
-    val allParameters: List<String>
+        val requestResponse: IHttpRequestResponsePersisted,
+        val dateTime: String,
+        val host: String,
+        val url: URL,
+        val types: Set<String>,
+        val parameter: String,
+        val method: String,
+        val statusCode: Short,
+        val title: String,
+        val length: Int,
+        val mimeType: String,
+        val protocol: String,
+        val file: String,
+        var comments: String,
+        val allParameters: List<String>
 )


### PR DESCRIPTION
**Updates:**
- Add options panel (Thanks @SimoneBovi)
   - Add ability to ignore duplicate issues, on by default (issue #72)
      - Add ability to ignore hosts when considering duplicate issues
   - Add ability to load proxy history from startup or manual, on by default (issue #71)
   - Make proxy history highlighting an option
- Idiomatic Kotlin fixes (Thanks @Advice-Dog) and logic separation